### PR TITLE
Add support for nodeSelector in helm chart

### DIFF
--- a/charts/connector/templates/deployment.yaml
+++ b/charts/connector/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
         volumeMounts:
         - mountPath: /dev/net/tun
           name: dev-tun
+        {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
       securityContext:
         fsGroup: 65534
       volumes:

--- a/charts/connector/values.yaml
+++ b/charts/connector/values.yaml
@@ -32,6 +32,9 @@ commonLabels: {}
 # Provide any annotations that you would like to add to the deployment.
 annotations: {}
 
+# Provide node selectors that you would like to add to the deployment.
+nodeSelector: {}
+
 # Service account for the connnector to use.
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
Users might want to control where the deployment pods run: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/