### PR TITLE
Add missing end to deployment.yaml

### DIFF
--- a/charts/connector/templates/deployment.yaml
+++ b/charts/connector/templates/deployment.yaml
@@ -57,9 +57,10 @@ spec:
         volumeMounts:
         - mountPath: /dev/net/tun
           name: dev-tun
-        {{- with .Values.nodeSelector }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         fsGroup: 65534
       volumes:


### PR DESCRIPTION
https://github.com/edgeguardian/helm-charts/pull/2 actually missed it.

## Test Plan

**Before:**

```
$ helm template --set connectorToken=foobar . > /dev/null
Error: parse error at (connector/templates/deployment.yaml:70): unexpected EOF

Use --debug flag to render out invalid YAML
```

**After:**

```
$ helm template --set connectorToken=foobar . > /dev/null
$ echo $?
0
```